### PR TITLE
enhancement: Fast Find for non-searchable Models

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -31,11 +31,25 @@ class Query
      */
     public function find(?string $id): ?Model
     {
-        if (! is_null($id)) {
+        if (is_null($id)) {
+            return null;
+        }
+
+        if (! empty($this->model->getSearchable())) {
             return $this->whereKey($id)->first();
         }
 
-        return null;
+        $hash = $this->model->getBaseHashWithKey($id);
+        $attributes = $this->cache->getAttributes($hash);
+
+        if (empty($attributes)) {
+            return null;
+        }
+
+        return $this->model->newFromBuilder([
+            ...$attributes,
+            $this->model->getKeyName() => $this->getKeyValue($hash),
+        ]);
     }
 
     /**


### PR DESCRIPTION
[`SCAN`](https://redis.io/docs/latest/commands/scan/) is a resource intensive and slow operation and, currently, it is the best way to implement Model searching.

However, not all Models are searchable, and when dealing with non-searchable models, we could skip the unnecessary `SCAN` and try to retrieve the model attributes using `HGETALL` directly, reducing the load on our Redis server(s).